### PR TITLE
Fix base URL for GitHub Pages deployment

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,5 +1,6 @@
 ## NOTE: CI workflow overrides this baseURL via --baseURL using actions/configure-pages output
-baseURL = "https://himiyosh.github.io/"
+# Set to project path so local builds and GitHub Pages resolve correctly
+baseURL = "https://himiyosh.github.io/HMStudio-T2/"
 languageCode = "ja-jp"
 title = "HMStudio"
 theme = "careercanvas"


### PR DESCRIPTION
## Summary
- set Hugo baseURL to project path so GitHub Pages serves pages correctly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build -- -d /tmp/public` *(fails: POSTCSS permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_689898df1d3c832b91ecfe68dde5da0a